### PR TITLE
feat: replace regex with provider function

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -90,7 +90,7 @@ resource "azurerm_lb" "loadbalancer" {
 }
 
 module "private_endpoints" {
-  source = "github.com/schubergphilis/terraform-azure-mcaf-private-endpoint?ref=v0.2.0"
+  source = "github.com/schubergphilis/terraform-azure-mcaf-private-endpoints?ref=v0.2.0"
 
   resource_group_name = local.resource_group_name
   location            = local.location

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -90,7 +90,7 @@ resource "azurerm_lb" "loadbalancer" {
 }
 
 module "private_endpoints" {
-  source = "github.com/schubergphilis/terraform-azure-mcaf-private-endpoints?ref=add_private_link"
+  source = "github.com/schubergphilis/terraform-azure-mcaf-private-endpoints"
 
   resource_group_name = local.resource_group_name
   location            = local.location

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -90,7 +90,7 @@ resource "azurerm_lb" "loadbalancer" {
 }
 
 module "private_endpoints" {
-  source = "github.com/schubergphilis/terraform-azure-mcaf-private-endpoints"
+  source = "github.com/schubergphilis/terraform-azure-mcaf-private-endpoint?ref=v0.2.0"
 
   resource_group_name = local.resource_group_name
   location            = local.location

--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,10 @@
 resource "azurerm_private_endpoint" "this" {
   for_each = var.private_endpoints
 
-  name                          = each.value.name != null ? each.value.name : "${provider::azurerm::parse_resource_id(each.value.private_connection_resource_id)["resource_name"]}-pep"
-  #name                          = each.value.name != null ? each.value.name : "${regex("([^/]+)$", each.value.private_connection_resource_id)[0]}-${each.value.subresource_name}-pep"
+  name                          = each.value.name != null ? each.value.name : "${provider::azurerm::parse_resource_id(each.value.private_connection_resource_id)["resource_name"]}-${each.value.subresource_name}-pep"
   location                      = var.location
   resource_group_name           = each.value.resource_group_name != null ? each.value.resource_group_name : var.resource_group_name
   subnet_id                     = each.value.subnet_id
-  #custom_network_interface_name = each.value.custom_network_interface_name != null ? each.value.custom_network_interface_name : "${regex("([^/]+)$", each.value.private_connection_resource_id)[0]}-nic"
   custom_network_interface_name = each.value.custom_network_interface_name != null ? each.value.custom_network_interface_name : "${provider::azurerm::parse_resource_id(each.value.private_connection_resource_id)["resource_name"]}-nic"
 
   private_service_connection {

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,13 @@
 resource "azurerm_private_endpoint" "this" {
   for_each = var.private_endpoints
 
-  name                          = each.value.name != null ? each.value.name : "${regex("([^/]+)$", each.value.private_connection_resource_id)[0]}-${each.value.subresource_name}-pep"
+  name                          = each.value.name != null ? each.value.name : "${provider::azurerm::parse_resource_id(each.value.private_connection_resource_id)["resource_name"]}-pep"
+  #name                          = each.value.name != null ? each.value.name : "${regex("([^/]+)$", each.value.private_connection_resource_id)[0]}-${each.value.subresource_name}-pep"
   location                      = var.location
   resource_group_name           = each.value.resource_group_name != null ? each.value.resource_group_name : var.resource_group_name
   subnet_id                     = each.value.subnet_id
-  custom_network_interface_name = each.value.custom_network_interface_name != null ? each.value.custom_network_interface_name : "${regex("([^/]+)$", each.value.private_connection_resource_id)[0]}-nic"
+  #custom_network_interface_name = each.value.custom_network_interface_name != null ? each.value.custom_network_interface_name : "${regex("([^/]+)$", each.value.private_connection_resource_id)[0]}-nic"
+  custom_network_interface_name = each.value.custom_network_interface_name != null ? each.value.custom_network_interface_name : "${provider::azurerm::parse_resource_id(each.value.private_connection_resource_id)["resource_name"]}-nic"
 
   private_service_connection {
     name                              = each.value.private_service_connection_name != null ? each.value.private_service_connection_name : "${each.key}_psc"

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.7"
+  required_version = ">= 1.8"
 
   required_providers {
     azurerm = {

--- a/variables.tf
+++ b/variables.tf
@@ -24,7 +24,7 @@ variable "private_endpoints" {
     is_manual_connection              = optional(bool)
     private_connection_resource_alias = optional(string)
     private_connection_resource_id    = optional(string)
-    private_dns_zone_group_name             = optional(string, "default")
+    private_dns_zone_group_name       = optional(string, "default")
     private_dns_zone_resource_ids     = optional(list(string), [])
     private_service_connection_name   = optional(string)
     request_message                   = optional(string)


### PR DESCRIPTION
This change will go for a more native approach on splitting on names, instead of using regex we now use a new function from azurerm to split resources.

https://www.hashicorp.com/blog/terraform-azurerm-provider-4-0-adds-provider-defined-functions