### PR TITLE
bug: put default for location

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,7 @@
 variable "location" {
   description = "The location/region where the virtual network private endpoint is created."
   type        = string
+  default     = null
 }
 
 variable "resource_group_name" {


### PR DESCRIPTION
put a default for location, this is a bug, it should not be required, it should be used in conjunction with resourcegroup OR you pass it to the private_endpoints variable