### PR TITLE
feat: add unmanged dns option, for use with azure policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -81,7 +81,7 @@ resource "azurerm_private_endpoint" "this_unmanaged_dns_zone_groups" {
   )
 
   lifecycle {
-    ignore_changes = [ private_dns_zone_group ]
+    ignore_changes = [private_dns_zone_group]
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_private_endpoint" "this" {
-  for_each = var.private_endpoints
+  for_each = { for k, v in var.private_endpoints : k => v if v.private_endpoints_manage_dns_zone_group }
 
   name                          = each.value.name != null ? each.value.name : "${provider::azurerm::parse_resource_id(each.value.private_connection_resource_id)["resource_name"]}-${each.value.subresource_name}-pep"
   location                      = coalesce(each.value.location, var.location)
@@ -43,6 +43,48 @@ resource "azurerm_private_endpoint" "this" {
     })
   )
 }
+
+resource "azurerm_private_endpoint" "this_unmanaged_dns_zone_groups" {
+  for_each = { for k, v in var.private_endpoints : k => v if !v.private_endpoints_manage_dns_zone_group }
+
+  name                          = each.value.name != null ? each.value.name : "${provider::azurerm::parse_resource_id(each.value.private_connection_resource_id)["resource_name"]}-${each.value.subresource_name}-pep"
+  location                      = coalesce(each.value.location, var.location)
+  resource_group_name           = coalesce(each.value.resource_group_name, var.resource_group_name)
+  subnet_id                     = each.value.subnet_id
+  custom_network_interface_name = each.value.custom_network_interface_name != null ? each.value.custom_network_interface_name : "${provider::azurerm::parse_resource_id(each.value.private_connection_resource_id)["resource_name"]}-nic"
+
+  private_service_connection {
+    name                              = each.value.private_service_connection_name != null ? each.value.private_service_connection_name : "${each.key}_psc"
+    is_manual_connection              = each.value.is_manual_connection != null ? each.value.is_manual_connection : false
+    private_connection_resource_alias = each.value.private_connection_resource_alias != null ? each.value.private_connection_resource_alias : null
+    private_connection_resource_id    = each.value.private_connection_resource_id != null ? each.value.private_connection_resource_id : null
+    request_message                   = each.value.request_message != null ? each.value.request_message : null
+    subresource_names                 = each.value.subresource_name != null ? [each.value.subresource_name] : null
+  }
+
+  dynamic "ip_configuration" {
+    for_each = each.value.ip_configuration
+
+    content {
+      name               = ip_configuration.value.name != null ? ip_configuration.value.name : "${each.key}_ip"
+      member_name        = ip_configuration.value.member_name != null ? ip_configuration.value.member_name : "default"
+      private_ip_address = ip_configuration.value.private_ip_address
+      subresource_name   = ip_configuration.value.subresource_name != null ? ip_configuration.value.subresource_name : each.value.subresource_name
+    }
+  }
+
+  tags = merge(
+    try(each.value.tags),
+    tomap({
+      "Resource Type" = "Private Endpoint"
+    })
+  )
+
+  lifecycle {
+    ignore_changes = [ private_dns_zone_group ]
+  }
+}
+
 
 resource "azurerm_private_link_service" "this" {
   for_each = var.private_link_services

--- a/variables.tf
+++ b/variables.tf
@@ -22,17 +22,17 @@ variable "private_endpoints" {
       private_ip_address = optional(string)
       subresource_name   = optional(string)
     })), [])
-    is_manual_connection              = optional(bool)
-    private_connection_resource_alias = optional(string)
-    private_connection_resource_id    = optional(string)
-    private_dns_zone_group_name       = optional(string, "default")
-    private_dns_zone_resource_ids     = optional(list(string), [])
-    private_service_connection_name   = optional(string)
+    is_manual_connection                    = optional(bool)
+    private_connection_resource_alias       = optional(string)
+    private_connection_resource_id          = optional(string)
+    private_dns_zone_group_name             = optional(string, "default")
+    private_dns_zone_resource_ids           = optional(list(string), [])
+    private_service_connection_name         = optional(string)
     private_endpoints_manage_dns_zone_group = optional(bool, true)
-    request_message                   = optional(string)
-    subnet_id                         = string
-    subresource_name                  = optional(string)
-    tags                              = optional(map(string))
+    request_message                         = optional(string)
+    subnet_id                               = string
+    subresource_name                        = optional(string)
+    tags                                    = optional(map(string))
   }))
   default     = {}
   nullable    = false
@@ -54,6 +54,7 @@ This object describes the private endpoint configuration.
 - `private_dns_zone_group_name` - (Optional) Specifies the Name of the Private DNS Zone Group.
 - `private_dns_zone_ids` - (Optional) Specifies the list of Private DNS Zones to include.
 - `private_service_connection_name` - (Optional) Specifies the Name of the Private Service Connection.
+- `private_endpoints_manage_dns_zone_group` - (Optional) Should the Private Endpoint manage the DNS Zone Group, or manage it through azure policy for example, defaults to true.
 - `request_message` - (Optional) A message passed to the owner of the remote resource when the private endpoint attempts to establish the connection to the remote resource.
 - `subnet_id` - (Required) The ID of the Subnet from which Private IP Addresses will be allocated for this Private Endpoint.
 - `subresource_name` - (Optional) A subresource name which the Private Endpoint is able to connect to, e.g. 'vault' for key vault or 'blob' for storage account. Required when not using a custom Private Link service.
@@ -67,6 +68,7 @@ This object describes the private endpoint configuration.
       private_connection_resource_id = azurerm_storage_account.storage_account.id
       subnet_id                      = azurerm_subnet.app-subnet.id
       subresource_name               = "blob"
+      private_endpoints_manage_dns_zone_group = false
     }
   }
   ```hcl

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,7 @@ variable "private_endpoints" {
     private_dns_zone_group_name       = optional(string, "default")
     private_dns_zone_resource_ids     = optional(list(string), [])
     private_service_connection_name   = optional(string)
+    private_endpoints_manage_dns_zone_group = optional(bool, true)
     request_message                   = optional(string)
     subnet_id                         = string
     subresource_name                  = optional(string)


### PR DESCRIPTION
adding the option to also use PE without dns zone group config, since some or more teams will use azure policy to manage that part, so it needs to be excluded from management of TF