### PR TITLE
breaking: Change output to return endpoints by the same key as used in the input

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_private_endpoint_list"></a> [private\_endpoint\_list](#output\_private\_endpoint\_list) | A map of private endpoint names to their corresponding names and IDs |
+| <a name="output_private_endpoints"></a> [private\_endpoints](#output\_private\_endpoints) | A map of private endpoint names to their corresponding names and IDs |
 <!-- END_TF_DOCS -->
 
 ## License

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,15 +1,15 @@
-output "private_endpoint_list" {
+output "private_endpoints" {
   description = "A map of private endpoint names to their corresponding names and IDs"
   value = merge(
     {
-      for private_endpoint in azurerm_private_endpoint.this : private_endpoint.name => {
+      for name, private_endpoint in azurerm_private_endpoint.this : name => {
         name = private_endpoint.name
         id   = private_endpoint.id
         ip   = private_endpoint.private_service_connection[0].private_ip_address
       }
     },
     {
-      for private_endpoint in azurerm_private_endpoint.this_unmanaged_dns_zone_groups : private_endpoint.name => {
+      for name, private_endpoint in azurerm_private_endpoint.this_unmanaged_dns_zone_groups : name => {
         name = private_endpoint.name
         id   = private_endpoint.id
         ip   = private_endpoint.private_service_connection[0].private_ip_address


### PR DESCRIPTION
## :hammer_and_wrench: Summary

The current output can only be used when you know the generated name of the private endpoint. Therefore it is hard to use the output properly from a calling module.

After this change the output will be mapped with the same key used in the input.
The output has been slightly renamed to not hint at a list when a map is returned.
